### PR TITLE
Support WolverineFx 6.17

### DIFF
--- a/src/Tests/StreamResultTests.StreamResult.verified.txt
+++ b/src/Tests/StreamResultTests.StreamResult.verified.txt
@@ -1,0 +1,19 @@
+﻿{
+  context: {
+    Streamed: [
+      {
+        Message: {
+          Property: value
+        }
+      }
+    ]
+  },
+  Received: [
+    {
+      Property: Response one
+    },
+    {
+      Property: Response two
+    }
+  ]
+}

--- a/src/Tests/StreamResultTests.cs
+++ b/src/Tests/StreamResultTests.cs
@@ -1,0 +1,35 @@
+// ReSharper disable ArrangeObjectCreationWhenTypeNotEvident
+
+public class StreamResultTests
+{
+    [Fact]
+    public async Task StreamResult()
+    {
+        var context = new RecordingMessageContext();
+        context.AddStreamResult(
+            new Response("Response one"),
+            new Response("Response two"));
+        var handler = new Handler(context);
+        await handler.Handle(new Message("value"));
+        await Verify(
+            new
+            {
+                context,
+                handler.Received
+            });
+    }
+
+    class Handler(IMessageBus context)
+    {
+        public List<Response> Received { get; } = [];
+
+        public async Task Handle(Message message)
+        {
+            var request = new Request(message.Property);
+            await foreach (var response in context.StreamAsync<Response>(request))
+            {
+                Received.Add(response);
+            }
+        }
+    }
+}

--- a/src/Tests/Tests.AllTest.verified.txt
+++ b/src/Tests/Tests.AllTest.verified.txt
@@ -59,5 +59,20 @@
       },
       Endpoint: endpoint
     }
+  ],
+  Streamed: [
+    {
+      Message: {
+        Property: Property Value
+      }
+    },
+    {
+      Message: {
+        Property: Property Value
+      },
+      Options: {
+        DeliverBy: DateTimeOffset_5
+      }
+    }
   ]
 }

--- a/src/Tests/Tests.cs
+++ b/src/Tests/Tests.cs
@@ -72,5 +72,16 @@ public class AllHandler(IMessageContext context)
         await destination.InvokeAsync(
             new Response("Property Value"),
             timeout: TimeSpan.FromDays(2));
+        await foreach (var _ in context.StreamAsync<Response>(new Response("Property Value")))
+        {
+        }
+        await foreach (var _ in context.StreamAsync<Response>(
+            new Response("Property Value"),
+            new DeliveryOptions
+            {
+                DeliverWithin = TimeSpan.FromDays(4)
+            }))
+        {
+        }
     }
 }

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <RootNamespace>testing</RootNamespace>
   </PropertyGroup>

--- a/src/Verify.Wolverine/Converters/RecordingMessageContext_Stream.cs
+++ b/src/Verify.Wolverine/Converters/RecordingMessageContext_Stream.cs
@@ -1,0 +1,42 @@
+namespace VerifyTests.Wolverine;
+
+public partial class RecordingMessageContext
+{
+    List<Streamed> streamed = [];
+    public IReadOnlyList<Streamed> Streamed => streamed;
+
+    Dictionary<Type, Func<object, IEnumerable<object>>> streamResults = [];
+
+    public void AddStreamResult<T>(params T[] results)
+        where T : notnull =>
+        streamResults[typeof(T)] = _ => results.Cast<object>();
+
+    public IAsyncEnumerable<TResponse> StreamAsync<TResponse>(object message, Cancel cancellation = default)
+    {
+        streamed.Add(new(message));
+        return Stream<TResponse>(message);
+    }
+
+    public IAsyncEnumerable<TResponse> StreamAsync<TResponse>(object message, DeliveryOptions options, Cancel cancellation = default)
+    {
+        streamed.Add(new(message, options));
+        return Stream<TResponse>(message);
+    }
+
+    async IAsyncEnumerable<TResponse> Stream<TResponse>(object message)
+    {
+        await Task.CompletedTask;
+
+        if (!streamResults.TryGetValue(typeof(TResponse), out var func))
+        {
+            yield break;
+        }
+
+        foreach (var item in func(message))
+        {
+            yield return (TResponse) item;
+        }
+    }
+}
+
+public record Streamed(object Message, DeliveryOptions? Options = null);

--- a/src/Verify.Wolverine/Verify.Wolverine.csproj
+++ b/src/Verify.Wolverine/Verify.Wolverine.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Verify" />


### PR DESCRIPTION
WolverineFx 6.17 dropped net8.0 and added streaming to ICommandBus.

* Target net9.0 (lowest framework 6.17 supports)
* Implement the new StreamAsync overloads on RecordingMessageContext, with AddStreamResult to configure the streamed responses
* Record streamed calls (message + DeliveryOptions) for verification
* Add tests